### PR TITLE
Update AmazonSNS.php

### DIFF
--- a/lib/AmazonSNS.php
+++ b/lib/AmazonSNS.php
@@ -306,12 +306,13 @@ class AmazonSNS {
 	 *
 	 * @link http://docs.amazonwebservices.com/sns/latest/api/API_Publish.html
 	 * @param string $topicArn
-	 * @param string $message
+	 * @param string $message 
 	 * @param string $subject [optional] Used when sending emails
+	 * @param string $messageStructure [optional] Used when you want to send a different message for each protocol.If you set MessageStructure to json, the value of the Message parameter must: be a syntactically valid JSON object; and contain at least a top-level JSON key of "default" with a value that is a string.
 	 * @return string
 	 * @throws InvalidArgumentException
 	 */
-	public function publish($topicArn, $message, $subject = '') {
+	public function publish($topicArn, $message, $subject = '', $messageStructure = '') {
 		if(empty($topicArn) || empty($message)) {
 			throw new InvalidArgumentException('Must supply a TopicARN and Message to publish to a topic');
 		}
@@ -323,6 +324,10 @@ class AmazonSNS {
 
 		if(!empty($subject)) {
 			$params['Subject'] = $subject;
+		}
+
+		if(!empty($messageStructure)) {
+			$params['MessageStructure'] = $messageStructure;
 		}
 
 		$resultXml = $this->_request('Publish', $params);


### PR DESCRIPTION
Adding support for sending message in JSON format. Its useful when we want to send a different message for each protocol. For example, using one publish action, you can send a short message to your SMS subscribers and a longer message to your email subscribers.